### PR TITLE
add radar and alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/webdestroya/lita-weather/badge.png)](https://coveralls.io/r/webdestroya/lita-weather)
 
 **lita-weather** is a handler for [Lita](https://github.com/jimmycuadra/lita) that provides current weather information for a specific location.
+It also provides radar and you can check for any weather alerts issued in your area.
 
 ## Installation
 
@@ -30,6 +31,8 @@ end
 Lita: weather 90210
 Lita: weather LAX
 Lita: weather beverly hills, ca
+Lita: radar dallas, tx
+Lita: alerts kansas city, ks
 ```
 
 ## License

--- a/lib/lita/handlers/weather.rb
+++ b/lib/lita/handlers/weather.rb
@@ -18,6 +18,22 @@ module Lita
 
       route %r{^weather (.+\s*,\s*[a-z]{2})$}i, :weather_city, command: true
 
+      route %r{^radar (.+\s*),\s*([a-z]{2})$}i, :radar_city, command: true, help: {
+        'radar <city,state>' => 'Returns the current radar for the specified city'}
+
+      route %r{^alerts (.+\s*),\s*([a-z]{2})$}i, :alert_city, command: true, help: {
+        'alerts <city,state>' => 'Returns current weather alerts for the specified city'}
+
+      def radar_city(response)
+        return if Lita.config.handlers.weather.api_key.nil?
+        response.reply get_radar(response.matches[0])
+      end
+
+      def alert_city(response)
+        return if Lita.config.handlers.weather.api_key.nil?
+        response.reply get_alert(response.matches[0])
+      end
+
       def weather_zip(response)
         return if Lita.config.handlers.weather.api_key.nil?
         response.reply get_conditions(response.matches[0][0])
@@ -58,12 +74,54 @@ module Lita
 
       private
 
+      def get_radar(query)
+        # http://api.wunderground.com/api/KEY/alerts/q/TX/Dallas.gif?width=280&height=280&newmaps=1
+        # the width and height are adjustable if you want a larger or smaller gif
+        "http://api.wunderground.com/api/#{Lita.config.handlers.weather.api_key}/animatedradar/q/#{query[1]}/#{query[0].tr(' ', '_')}.gif?width=280&height=280&newmaps=1"
+      end
+
+      # Finds any weather alerts such as a tornado watch, severe thunderstorm warning, etc, for the specified city
+      def get_alert(query)
+        # http://api.wunderground.com/api/KEY/alerts/q/TX/Dallas.json
+        resp = http.get("http://api.wunderground.com/api/#{Lita.config.handlers.weather.api_key}/alerts/q/#{query[1]}/#{query[0].tr(' ', '_')}.json")
+
+        raise 'InvalidResponse' unless resp.status == 200
+
+        obj = MultiJson.load(resp.body)
+
+        # check for an error response
+        if obj['response']['error']
+          return obj['response']['error']['description']
+        end
+
+        alerts = obj['alerts']
+
+        response = ''
+
+        #checks for any number of alerts
+        alerts.each do |alert|
+          line = []
+          line << "#{alert['description']}, expires @ #{alert['expires']}"
+          line << "#{alert['message']}"
+          response << line.join(' - ')
+        end
+
+        if response == ""
+          'There are currently no alerts for this city'
+        else
+          response
+        end
+
+      rescue
+        'Sorry, but there was a problem retrieving weather information.'
+      end
+
       def get_conditions(query)
         # http://api.wunderground.com/api/KEY/conditions/q/37.7749295,-122.4194155.json
         resp = http.get("http://api.wunderground.com/api/#{Lita.config.handlers.weather.api_key}/conditions/q/#{query}.json")
 
         raise 'InvalidResponse' unless resp.status == 200
-        
+
         obj = MultiJson.load(resp.body)
         
         # check for an error response
@@ -77,7 +135,6 @@ module Lita
         line << "#{current['display_location']['full']} (#{current['display_location']['zip']})"
         line << "#{current['weather']} @ #{current['temperature_string']}"
         line << "Humidity: #{current['relative_humidity']}, Winds: #{current['wind_string']}"
-
         line.join ' - '
 
       rescue
@@ -85,7 +142,6 @@ module Lita
       end
 
     end
-
     Lita.register_handler(Weather)
   end
 end

--- a/spec/lita/handlers/weather_spec.rb
+++ b/spec/lita/handlers/weather_spec.rb
@@ -22,13 +22,19 @@ describe Lita::Handlers::Weather, lita_handler: true do
 
   it { doesnt_route_command("weather ca").to(:weather_city) }
 
+  it { is_expected.to route_command("radar Dallas,TX").to(:radar_city) }
+  it { is_expected.to route_command("alerts Dallas,TX").to(:alert_city) }
+
+  it { is_expected.not_to route_command("radar").to(:radar_city) }
+  it { is_expected.not_to route_command("12345").to(:radar_city) }
+  it { is_expected.not_to route_command("alerts").to(:alert_city) }
+  it { is_expected.not_to route_command("12345").to(:alert_city) }
 
   it "checks invalid zipcode" do
     send_command "weather 11111"
     expect(replies.last).to_not be_nil
     expect(replies.last).to eq("No cities match your search query")
   end
-
 
   it "checks valid zipcode" do
     send_command "weather 90210"
@@ -48,5 +54,16 @@ describe Lita::Handlers::Weather, lita_handler: true do
     expect(replies.last).to include("Los Angeles International")
   end
 
+  it "checks valid city for radar" do
+    send_command "radar Dallas,TX"
+    expect(replies.last).to_not be_nil
+    expect(replies.last).to include("Dallas")
+  end
+
+  it "checks valid city for alerts" do
+    send_command "alerts Dallas,TX"
+    expect(replies.last).to_not be_nil
+    expect(replies.last).to include("Dallas")
+  end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,6 @@ SimpleCov.start { add_filter "/spec/" }
 
 require "lita-weather"
 require "lita/rspec"
+
+# Had to set this to false to get spec tests to work
+Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
I created commands so you can pull a radar gif from weather underground, and you can also get weather alerts for you area, such as a severe thunderstorm warning or a flood warning. The alerts command should work in any adapter, because it's just text. I tested the radar command in HipChat and it worked great in HipChat. It should work in any other adapter that supports gif links, but I only tested it in HipChat so I can't confirm it works with other adapters. The command syntax is in the readme.
